### PR TITLE
Translation localisation  for mac-os

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,8 +205,9 @@ IF( APPLE )
       )
     ADD_CUSTOM_COMMAND( TARGET ${PROGNAME} POST_BUILD
       COMMAND mkdir ARGS ${CMAKE_CURRENT_BINARY_DIR}/${PROGNAME}.app/Contents/Resources
+      COMMAND mkdir ARGS ${CMAKE_CURRENT_BINARY_DIR}/${PROGNAME}.app/Contents/Resources/lang
       COMMAND cp ARGS ${MACOSX_BUNDLE_ICON_FILE} ${CMAKE_CURRENT_BINARY_DIR}/${PROGNAME}.app/Contents/Resources
-      #COMMAND cp ARGS *.qm ${CMAKE_CURRENT_BINARY_DIR}/${PROGNAME}.app/Contents/Resources 
+      COMMAND cp ARGS ../lang/*.qm ${CMAKE_CURRENT_BINARY_DIR}/${PROGNAME}.app/Contents/Resources/lang
       )
 
 ELSE( APPLE )

--- a/src/main.cc
+++ b/src/main.cc
@@ -21,6 +21,9 @@
 //******************************************************************************
 int main( int argc, char * argv[] )
 {
+  //mac os, need to instanciate aplpication fist to get it's path
+  QApplication app(argc, argv);
+
   Q_INIT_RESOURCE(songbook);
 
   QCoreApplication::setOrganizationName("Patacrep");
@@ -33,8 +36,17 @@ int main( int argc, char * argv[] )
   QString filename = QString("songbook_%1").arg(locale) + ".qm";
   QString dir;
 
+  #ifndef __APPLE__
   const QDir systemDir("/usr/share/songbook-client/translations", "*.qm");
   const QDir userDir("/usr/local/share/songbook-client/translations", "*.qm");
+  #endif
+  #ifdef __APPLE__
+  QDir cdir(app.applicationDirPath());
+  cdir.cdUp();
+  cdir.cd("Resources/lang");
+  const QDir systemDir(cdir.absolutePath());
+  const QDir userDir(cdir.absolutePath());
+  #endif
 
   if (systemDir.entryList(QDir::Files | QDir::Readable).contains(filename))
     dir = systemDir.absolutePath();
@@ -47,7 +59,7 @@ int main( int argc, char * argv[] )
   translator.load(QString("songbook_%1").arg(locale), dir);
 
   // Main application
-  QApplication app(argc, argv);
+  // move app creation to beggining
   app.installTranslator(&translator);
 
   CMainWindow mainWindow;


### PR DESCRIPTION
Les fichiers de localisation ne sont pas dans /usr/share pour mac, 
j'ai modifié le CMakelist en conséquence, 
et ajouté un ifdef **APPLE** dans le main

j'ai du déplacer la création du QApplication un peu plus tôt dans le main.

Ça ne devrais a priori rien changer pour linux (hormis Free BSD qui parfois se prends pour **APPLE**) avec CMake.
